### PR TITLE
Add wrapper structs for X509/X509_CRL

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -946,6 +946,22 @@ typedef uint8_t (*s2n_verify_host_fn) (const char *host_name, size_t host_name_l
 S2N_API
 extern int s2n_config_set_verify_host_callback(struct s2n_config *config, s2n_verify_host_fn, void *data);
 
+struct s2n_x509_cert;
+
+S2N_API
+extern int s2n_x509_cert_get_issuer_hash(struct s2n_x509_cert *cert, unsigned long *hash);
+
+struct s2n_x509_crl;
+
+S2N_API
+extern int s2n_x509_crl_from_pem(char *pem, struct s2n_x509_crl **crl);
+
+S2N_API
+extern int s2n_x509_crl_free(struct s2n_x509_crl *crl);
+
+S2N_API
+extern int s2n_x509_crl_get_issuer_hash(struct s2n_x509_crl *crl, unsigned long *hash);
+
 /**
  * Toggles whether or not to validate stapled OCSP responses.
  *

--- a/stuffer/s2n_stuffer.h
+++ b/stuffer/s2n_stuffer.h
@@ -167,6 +167,9 @@ extern int s2n_stuffer_private_key_from_pem(struct s2n_stuffer *pem, struct s2n_
 /* Read a certificate  from a PEM encoded stuffer to an ASN1/DER encoded one */
 extern int s2n_stuffer_certificate_from_pem(struct s2n_stuffer *pem, struct s2n_stuffer *asn1);
 
+/* Read a CRL from a PEM encoded stuffer to an ASN1/DER encoded one */
+extern int s2n_stuffer_crl_from_pem(struct s2n_stuffer *pem, struct s2n_stuffer *asn1);
+
 /* Read DH parameters om a PEM encoded stuffer to a PKCS3 encoded one */
 extern int s2n_stuffer_dhparams_from_pem(struct s2n_stuffer *pem, struct s2n_stuffer *pkcs3);
 

--- a/stuffer/s2n_stuffer_pem.c
+++ b/stuffer/s2n_stuffer_pem.c
@@ -31,6 +31,7 @@
 #define S2N_PEM_DH_PARAMETERS               "DH PARAMETERS"
 #define S2N_PEM_EC_PARAMETERS               "EC PARAMETERS"
 #define S2N_PEM_CERTIFICATE                 "CERTIFICATE"
+#define S2N_PEM_CRL                         "X509 CRL"
 
 static int s2n_stuffer_pem_read_encapsulation_line(struct s2n_stuffer *pem, const char* encap_marker, const char *keyword) {
 
@@ -163,6 +164,10 @@ int s2n_stuffer_private_key_from_pem(struct s2n_stuffer *pem, struct s2n_stuffer
 int s2n_stuffer_certificate_from_pem(struct s2n_stuffer *pem, struct s2n_stuffer *asn1)
 {
     return s2n_stuffer_data_from_pem(pem, asn1, S2N_PEM_CERTIFICATE);
+}
+
+int s2n_stuffer_crl_from_pem(struct s2n_stuffer *pem, struct s2n_stuffer *asn1) {
+    return s2n_stuffer_data_from_pem(pem, asn1, S2N_PEM_CRL);
 }
 
 int s2n_stuffer_dhparams_from_pem(struct s2n_stuffer *pem, struct s2n_stuffer *pkcs3)

--- a/tests/testlib/s2n_test_certs.c
+++ b/tests/testlib/s2n_test_certs.c
@@ -76,3 +76,9 @@ int s2n_read_test_pem_and_len(const char *pem_path, uint8_t *pem_out, uint32_t *
     return 0;
 }
 
+int free_char_array_pointer(char** array) {
+    if (array && *array) {
+        free(*array);
+    }
+    return S2N_SUCCESS;
+}

--- a/tests/testlib/s2n_testlib.h
+++ b/tests/testlib/s2n_testlib.h
@@ -83,7 +83,7 @@ S2N_RESULT s2n_connection_set_test_early_secret(struct s2n_connection *conn, con
 S2N_RESULT s2n_connection_set_test_handshake_secret(struct s2n_connection *conn, const struct s2n_blob *handshake_secret);
 S2N_RESULT s2n_connection_set_test_master_secret(struct s2n_connection *conn, const struct s2n_blob *master_secret);
 
-#define S2N_MAX_TEST_PEM_SIZE 4096
+#define S2N_MAX_TEST_PEM_SIZE 8192
 
 /* These paths assume that the unit tests are run from inside the unit/ directory.
  * Absolute paths will be needed if test directories go to deeper levels.
@@ -166,6 +166,22 @@ S2N_RESULT s2n_connection_set_test_master_secret(struct s2n_connection *conn, co
 
 #define S2N_DEFAULT_TEST_DHPARAMS S2N_DHPARAMS_2048
 
+/* CRL testing files */
+#define S2N_CRL_ROOT_CERT                               "../pems/crl/root_cert.pem"
+#define S2N_CRL_NONE_REVOKED_CERT_CHAIN                 "../pems/crl/none_revoked_cert_chain.pem"
+#define S2N_CRL_NONE_REVOKED_KEY                        "../pems/crl/none_revoked_key.pem"
+#define S2N_CRL_INTERMEDIATE_REVOKED_CERT_CHAIN         "../pems/crl/intermediate_revoked_cert_chain.pem"
+#define S2N_CRL_INTERMEDIATE_REVOKED_KEY                "../pems/crl/intermediate_revoked_key.pem"
+#define S2N_CRL_LEAF_REVOKED_CERT_CHAIN                 "../pems/crl/leaf_revoked_cert_chain.pem"
+#define S2N_CRL_LEAF_REVOKED_KEY                        "../pems/crl/leaf_revoked_key.pem"
+#define S2N_CRL_ALL_REVOKED_CERT_CHAIN                  "../pems/crl/all_revoked_cert_chain.pem"
+#define S2N_CRL_ALL_REVOKED_KEY                         "../pems/crl/all_revoked_key.pem"
+#define S2N_CRL_ROOT_CRL                                "../pems/crl/root_crl.pem"
+#define S2N_CRL_INTERMEDIATE_CRL                        "../pems/crl/intermediate_crl.pem"
+#define S2N_CRL_INTERMEDIATE_REVOKED_CRL                "../pems/crl/intermediate_revoked_crl.pem"
+#define S2N_CRL_INTERMEDIATE_INVALID_LAST_UPDATE_CRL    "../pems/crl/intermediate_invalid_last_update_crl.pem"
+#define S2N_CRL_INTERMEDIATE_INVALID_NEXT_UPDATE_CRL    "../pems/crl/intermediate_invalid_next_update_crl.pem"
+
 /* Read a cert given a path into pem_out */
 int s2n_read_test_pem(const char *pem_path, char *pem_out, long int max_size);
 int s2n_read_test_pem_and_len(const char *pem_path, uint8_t *pem_out, uint32_t *pem_len, long int max_size);
@@ -221,3 +237,5 @@ extern const s2n_parsed_extension EMPTY_PARSED_EXTENSIONS[S2N_PARSED_EXTENSIONS_
 int s2n_kem_recv_public_key_fuzz_test(const uint8_t *buf, size_t len, struct s2n_kem_params *kem_params);
 int s2n_kem_recv_ciphertext_fuzz_test(const uint8_t *buf, size_t len, struct s2n_kem_params *kem_params);
 int s2n_kem_recv_ciphertext_fuzz_test_init(const char *kat_file_path, struct s2n_kem_params *kem_params);
+
+int free_char_array_pointer(char** array);

--- a/tests/unit/s2n_x509_validator_test.c
+++ b/tests/unit/s2n_x509_validator_test.c
@@ -16,6 +16,11 @@
 #include "s2n_test.h"
 #include "testlib/s2n_testlib.h"
 
+#define CRL_TEST_CHAIN_LEN 2
+
+DEFINE_POINTER_CLEANUP_FUNC(struct s2n_x509_cert*, s2n_x509_cert_free);
+DEFINE_POINTER_CLEANUP_FUNC(struct s2n_x509_crl*, s2n_x509_crl_free);
+
 static int fetch_expired_after_ocsp_timestamp(void *data, uint64_t *timestamp) {
     *timestamp = 7283958536000000000;
     return 0;
@@ -1633,6 +1638,177 @@ int main(int argc, char **argv) {
             EXPECT_TRUE(s2n_x509_trust_store_has_certs(&cfg->trust_store));
             free(cert_chain);
             s2n_config_free(cfg);
+        }
+    }
+
+    /* Test CRL validation */
+    {
+        DEFER_CLEANUP(char *root_crl_pem = malloc(S2N_MAX_TEST_PEM_SIZE), free_char_array_pointer);
+        EXPECT_NOT_NULL(root_crl_pem);
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_CRL_ROOT_CRL, root_crl_pem, S2N_MAX_TEST_PEM_SIZE));
+        DEFER_CLEANUP(struct s2n_x509_crl *root_crl = NULL, s2n_x509_crl_free_pointer);
+        EXPECT_SUCCESS(s2n_x509_crl_from_pem(root_crl_pem, &root_crl));
+
+        DEFER_CLEANUP(char *intermediate_crl_pem = malloc(S2N_MAX_TEST_PEM_SIZE), free_char_array_pointer);
+        EXPECT_NOT_NULL(intermediate_crl_pem);
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_CRL_INTERMEDIATE_CRL, intermediate_crl_pem, S2N_MAX_TEST_PEM_SIZE));
+        DEFER_CLEANUP(struct s2n_x509_crl *intermediate_crl = NULL, s2n_x509_crl_free_pointer);
+        EXPECT_SUCCESS(s2n_x509_crl_from_pem(intermediate_crl_pem, &intermediate_crl));
+
+        DEFER_CLEANUP(char *intermediate_revoked_crl_pem = malloc(S2N_MAX_TEST_PEM_SIZE), free_char_array_pointer);
+        EXPECT_NOT_NULL(intermediate_revoked_crl_pem);
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_CRL_INTERMEDIATE_REVOKED_CRL, intermediate_revoked_crl_pem, S2N_MAX_TEST_PEM_SIZE));
+        DEFER_CLEANUP(struct s2n_x509_crl *intermediate_revoked_crl = NULL, s2n_x509_crl_free_pointer);
+        EXPECT_SUCCESS(s2n_x509_crl_from_pem(intermediate_revoked_crl_pem, &intermediate_revoked_crl));
+
+        /* Initialize a validator with X509s to use for s2n_x509_cert tests */
+        DEFER_CLEANUP(struct s2n_x509_validator retrieved_certs_validator, s2n_x509_validator_wipe);
+        {
+            DEFER_CLEANUP(struct s2n_x509_trust_store trust_store = { 0 }, s2n_x509_trust_store_wipe);
+            s2n_x509_trust_store_init_empty(&trust_store);
+
+            DEFER_CLEANUP(char *root_cert = malloc(S2N_MAX_TEST_PEM_SIZE), free_char_array_pointer);
+            EXPECT_NOT_NULL(root_cert);
+            EXPECT_SUCCESS(s2n_read_test_pem(S2N_CRL_ROOT_CERT, root_cert, S2N_MAX_TEST_PEM_SIZE));
+            EXPECT_SUCCESS(s2n_x509_trust_store_add_pem(&trust_store, root_cert));
+
+            EXPECT_SUCCESS(s2n_x509_validator_init(&retrieved_certs_validator, &trust_store, 0));
+
+            DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+            EXPECT_NOT_NULL(config);
+
+            DEFER_CLEANUP(struct s2n_array *crls = s2n_array_new(sizeof(struct s2n_x509_crl)), s2n_array_free_p);
+            EXPECT_NOT_NULL(crls);
+
+            DEFER_CLEANUP(struct s2n_connection *connection = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
+            EXPECT_NOT_NULL(connection);
+            EXPECT_SUCCESS(s2n_connection_set_config(connection, config));
+            EXPECT_SUCCESS(s2n_set_server_name(connection, "localhost"));
+
+            uint8_t cert_chain_pem[S2N_MAX_TEST_PEM_SIZE];
+            EXPECT_SUCCESS(s2n_read_test_pem(S2N_CRL_NONE_REVOKED_CERT_CHAIN, (char *) cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
+            DEFER_CLEANUP(struct s2n_stuffer chain_stuffer = { 0 }, s2n_stuffer_free);
+            uint32_t chain_len = write_pem_file_to_stuffer_as_chain(&chain_stuffer, (const char *) cert_chain_pem, S2N_TLS12);
+            EXPECT_TRUE(chain_len > 0);
+            uint8_t *chain_data = s2n_stuffer_raw_read(&chain_stuffer, ( uint32_t )chain_len);
+
+            DEFER_CLEANUP(struct s2n_pkey public_key_out = { 0 }, s2n_pkey_free);
+            EXPECT_SUCCESS(s2n_pkey_zero_init(&public_key_out));
+            s2n_pkey_type pkey_type = S2N_PKEY_TYPE_UNKNOWN;
+            EXPECT_OK(s2n_x509_validator_validate_cert_chain(&retrieved_certs_validator, connection, chain_data,
+                                                             chain_len, &pkey_type, &public_key_out));
+            EXPECT_EQUAL(S2N_PKEY_TYPE_RSA, pkey_type);
+        }
+
+        /* Initializing and freeing empty s2n_x509_cert succeeds */
+        {
+            DEFER_CLEANUP(struct s2n_x509_cert *cert = s2n_x509_cert_new(), s2n_x509_cert_free_pointer);
+            EXPECT_NOT_NULL(cert);
+            EXPECT_NULL(cert->cert);
+        }
+
+        /* Freeing a populated s2n_x509_cert succeeds and doesn't free the internal X509 */
+        {
+            struct s2n_x509_cert *cert = s2n_x509_cert_new();
+            EXPECT_NOT_NULL(cert);
+            EXPECT_NULL(cert->cert);
+
+            EXPECT_TRUE(sk_X509_num(retrieved_certs_validator.cert_chain_from_wire) > 0);
+            X509 *internal_cert = sk_X509_value(retrieved_certs_validator.cert_chain_from_wire, 0);
+            EXPECT_NOT_NULL(internal_cert);
+
+            cert->cert = internal_cert;
+
+            EXPECT_SUCCESS(s2n_x509_cert_free(cert));
+
+            /* Make sure an OpenSSL operation succeeds on the internal X509 */
+            X509_NAME *crl_name = X509_get_issuer_name(internal_cert);
+            POSIX_ENSURE_REF(crl_name);
+        }
+
+        /* Ensure s2n_x509_crl_from_pem produces a valid X509_CRL internally */
+        {
+            EXPECT_NOT_NULL(root_crl->crl);
+
+            /* Make sure an OpenSSL operation succeeds on the internal X509_CRL */
+            X509_NAME *crl_name = X509_CRL_get_issuer(root_crl->crl);
+            POSIX_ENSURE_REF(crl_name);
+        }
+
+        /* s2n_x509_crl_from_pem fails if provided a bad pem */
+        {
+            DEFER_CLEANUP(char *invalid_crl_pem = malloc(S2N_MAX_TEST_PEM_SIZE), free_char_array_pointer);
+            EXPECT_NOT_NULL(invalid_crl_pem);
+            EXPECT_SUCCESS(s2n_read_test_pem(S2N_CRL_ROOT_CRL, invalid_crl_pem, S2N_MAX_TEST_PEM_SIZE));
+
+            /* Change a random byte in the pem to make it invalid */
+            invalid_crl_pem[50] = 1;
+
+            DEFER_CLEANUP(struct s2n_x509_crl *invalid_crl = NULL, s2n_x509_crl_free_pointer);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_x509_crl_from_pem(invalid_crl_pem, &invalid_crl),
+                    S2N_ERR_INTERNAL_LIBCRYPTO_ERROR);
+        }
+
+        /* Certificate issuer hash is retrieved successfully */
+        {
+            DEFER_CLEANUP(struct s2n_x509_cert *cert = s2n_x509_cert_new(), s2n_x509_cert_free_pointer);
+            EXPECT_NOT_NULL(cert);
+
+            EXPECT_TRUE(sk_X509_num(retrieved_certs_validator.cert_chain_from_wire) > 0);
+            X509 *internal_cert = sk_X509_value(retrieved_certs_validator.cert_chain_from_wire, 0);
+            EXPECT_NOT_NULL(internal_cert);
+            cert->cert = internal_cert;
+
+            unsigned long hash = 0;
+            EXPECT_SUCCESS(s2n_x509_cert_get_issuer_hash(cert, &hash));
+            EXPECT_TRUE(hash != 0);
+        }
+
+        /* CRL issuer hash is retrieved successfully */
+        {
+            unsigned long hash = 0;
+            EXPECT_SUCCESS(s2n_x509_crl_get_issuer_hash(root_crl, &hash));
+            EXPECT_TRUE(hash != 0);
+        }
+
+        /* Retrieved hash values for certificates match CRL hashes */
+        {
+            /* Create leaf cert */
+            DEFER_CLEANUP(struct s2n_x509_cert *leaf_cert = s2n_x509_cert_new(), s2n_x509_cert_free_pointer);
+            EXPECT_NOT_NULL(leaf_cert);
+            EXPECT_TRUE(sk_X509_num(retrieved_certs_validator.cert_chain_from_wire) > 1);
+            X509 *internal_leaf_cert = sk_X509_value(retrieved_certs_validator.cert_chain_from_wire, 0);
+            EXPECT_NOT_NULL(internal_leaf_cert);
+            leaf_cert->cert = internal_leaf_cert;
+
+            /* Create intermediate cert */
+            DEFER_CLEANUP(struct s2n_x509_cert *intermediate_cert = s2n_x509_cert_new(), s2n_x509_cert_free_pointer);
+            EXPECT_NOT_NULL(intermediate_cert);
+            X509 *internal_intermediate_cert = sk_X509_value(retrieved_certs_validator.cert_chain_from_wire, 1);
+            EXPECT_NOT_NULL(internal_intermediate_cert);
+            intermediate_cert->cert = internal_intermediate_cert;
+
+            unsigned long intermediate_crl_hash = 0;
+            EXPECT_SUCCESS(s2n_x509_crl_get_issuer_hash(intermediate_crl, &intermediate_crl_hash));
+            EXPECT_TRUE(intermediate_crl_hash != 0);
+
+            unsigned long leaf_cert_hash = 0;
+            EXPECT_SUCCESS(s2n_x509_cert_get_issuer_hash(leaf_cert, &leaf_cert_hash));
+            EXPECT_TRUE(leaf_cert_hash != 0);
+
+            EXPECT_TRUE(intermediate_crl_hash == leaf_cert_hash);
+
+            unsigned long root_crl_hash = 0;
+            EXPECT_SUCCESS(s2n_x509_crl_get_issuer_hash(root_crl, &root_crl_hash));
+            EXPECT_TRUE(root_crl_hash != 0);
+
+            unsigned long intermediate_cert_hash = 0;
+            EXPECT_SUCCESS(s2n_x509_cert_get_issuer_hash(intermediate_cert, &intermediate_cert_hash));
+            EXPECT_TRUE(intermediate_cert_hash != 0);
+
+            EXPECT_TRUE(root_crl_hash == intermediate_cert_hash);
+
+            EXPECT_TRUE(root_crl_hash != leaf_cert_hash);
         }
     }
 

--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -138,6 +138,100 @@ void s2n_x509_trust_store_wipe(struct s2n_x509_trust_store *store) {
     }
 }
 
+struct s2n_x509_cert* s2n_x509_cert_new(void) {
+    DEFER_CLEANUP(struct s2n_blob mem = { 0 }, s2n_free);
+    PTR_GUARD_POSIX(s2n_alloc(&mem, sizeof(struct s2n_x509_cert)));
+
+    struct s2n_x509_cert *cert = (struct s2n_x509_cert*)(void*) mem.data;
+    cert->cert = NULL;
+
+    ZERO_TO_DISABLE_DEFER_CLEANUP(mem);
+    return cert;
+}
+
+int s2n_x509_cert_free(struct s2n_x509_cert *cert) {
+    if (cert) {
+        POSIX_GUARD(s2n_free_object((uint8_t **) &cert, sizeof(struct s2n_x509_cert)));
+    }
+    return S2N_SUCCESS;
+}
+
+int s2n_x509_cert_get_issuer_hash(struct s2n_x509_cert *cert, unsigned long *hash) {
+    POSIX_ENSURE_REF(cert);
+    POSIX_ENSURE_REF(cert->cert);
+
+    unsigned long temp_hash = X509_issuer_name_hash(cert->cert);
+    POSIX_ENSURE(temp_hash != 0, S2N_ERR_INTERNAL_LIBCRYPTO_ERROR);
+
+    *hash = temp_hash;
+
+    return S2N_SUCCESS;
+}
+
+static struct s2n_x509_crl* s2n_x509_crl_new(void) {
+    DEFER_CLEANUP(struct s2n_blob mem = { 0 }, s2n_free);
+    PTR_GUARD_POSIX(s2n_alloc(&mem, sizeof(struct s2n_x509_crl)));
+
+    struct s2n_x509_crl *crl = (struct s2n_x509_crl*)(void*) mem.data;
+    crl->crl = NULL;
+
+    ZERO_TO_DISABLE_DEFER_CLEANUP(mem);
+    return crl;
+}
+
+int s2n_x509_crl_from_pem(char *pem, struct s2n_x509_crl **crl) {
+    POSIX_ENSURE_REF(crl);
+
+    DEFER_CLEANUP(struct s2n_stuffer pem_in_stuffer = {0}, s2n_stuffer_free);
+    DEFER_CLEANUP(struct s2n_stuffer der_out_stuffer = {0}, s2n_stuffer_free);
+
+    POSIX_GUARD(s2n_stuffer_alloc_ro_from_string(&pem_in_stuffer, pem));
+    POSIX_GUARD(s2n_stuffer_growable_alloc(&der_out_stuffer, 2048));
+
+    DEFER_CLEANUP(struct s2n_blob crl_blob = { 0 }, s2n_free);
+
+    POSIX_GUARD(s2n_stuffer_crl_from_pem(&pem_in_stuffer, &der_out_stuffer));
+    POSIX_GUARD(s2n_alloc(&crl_blob, s2n_stuffer_data_available(&der_out_stuffer)));
+    POSIX_GUARD(s2n_stuffer_read(&der_out_stuffer, &crl_blob));
+
+    *crl = s2n_x509_crl_new();
+    POSIX_ENSURE_REF(*crl);
+
+    const uint8_t *data = crl_blob.data;
+    (*crl)->crl = d2i_X509_CRL(NULL, &data, crl_blob.size);
+    POSIX_ENSURE((*crl)->crl != NULL, S2N_ERR_INTERNAL_LIBCRYPTO_ERROR);
+
+    return S2N_SUCCESS;
+}
+
+int s2n_x509_crl_free(struct s2n_x509_crl *crl) {
+    if (crl == NULL) {
+        return S2N_SUCCESS;
+    }
+
+    if (crl->crl) {
+        X509_CRL_free(crl->crl);
+    }
+    POSIX_GUARD(s2n_free_object((uint8_t **) &crl, sizeof(struct s2n_x509_crl)));
+
+    return S2N_SUCCESS;
+}
+
+int s2n_x509_crl_get_issuer_hash(struct s2n_x509_crl *crl, unsigned long *hash) {
+    POSIX_ENSURE_REF(crl);
+    POSIX_ENSURE_REF(crl->crl);
+
+    X509_NAME *crl_name = X509_CRL_get_issuer(crl->crl);
+    POSIX_ENSURE_REF(crl_name);
+
+    unsigned long temp_hash = X509_NAME_hash(crl_name);
+    POSIX_ENSURE(temp_hash != 0, S2N_ERR_INTERNAL_LIBCRYPTO_ERROR);
+
+    *hash = temp_hash;
+
+    return S2N_SUCCESS;
+}
+
 int s2n_x509_validator_init_no_x509_validation(struct s2n_x509_validator *validator) {
     POSIX_ENSURE_REF(validator);
     validator->trust_store = NULL;

--- a/tls/s2n_x509_validator.h
+++ b/tls/s2n_x509_validator.h
@@ -62,6 +62,20 @@ struct s2n_x509_validator {
     int state;
 };
 
+struct s2n_x509_cert {
+    X509 *cert;
+};
+
+struct s2n_x509_crl {
+    X509_CRL *crl;
+};
+
+/* Allocates a new s2n_x509_cert struct */
+struct s2n_x509_cert* s2n_x509_cert_new(void);
+
+/* Frees a s2n_x509_cert struct */
+int s2n_x509_cert_free(struct s2n_x509_cert *cert);
+
 /** Some libcrypto implementations do not support OCSP validation. Returns 1 if supported, 0 otherwise. */
 uint8_t s2n_x509_ocsp_stapling_supported(void);
 


### PR DESCRIPTION
### Resolved issues:

Part of https://github.com/aws/s2n-tls/issues/3499

### Description of changes: 

When a user implements a CRL lookup, they will need to return a CRL that s2n-tls can use for CRL validation. This PR adds an opaque `s2n_x509_crl` struct that users can create from a PEM, and can return from the CRL lookup.

Additionally, users must be able to know in the lookup which CRL to return. To support this, an `s2n_x509_cert` struct will be made available to the user in the lookup. Helper functions have been added to get the certificate's and crl's issuer hashes. The issuer hash of a certificate will match the issuer hash of the CRL.

### Call-outs:

None

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?
- Unit tests have been added to test the helper functions as well as creating/freeing the structs.

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
